### PR TITLE
Add support for TTF and WOFF font files

### DIFF
--- a/GK6X/WebGUI.cs
+++ b/GK6X/WebGUI.cs
@@ -908,6 +908,14 @@ namespace GK6X
                                     responseBuffer = File.ReadAllBytes(file);
                                     contentType = "text/css";
                                     break;
+                                case ".ttf":
+                                    responseBuffer = File.ReadAllBytes(file);
+                                    contentType = "font/ttf";
+                                    break;
+                                case ".woff":
+                                    responseBuffer = File.ReadAllBytes(file);
+                                    contentType = "font/woff";
+                                    break;
                                 default:
                                     Program.Log("Unhandled file type " + extension + " " + context.Request.Url.AbsolutePath);
                                     break;


### PR DESCRIPTION
# Problem I found:
![image](https://github.com/pixeltris/GK6X/assets/70655025/0ae7a2ab-21e2-4eb0-84e8-a25bc2a8442e)

Solution:
Add support for .ttf and .woff font files on the server.